### PR TITLE
Added in recognition for *.tps files

### DIFF
--- a/grammars/topas.cson
+++ b/grammars/topas.cson
@@ -1,7 +1,7 @@
 {
   "name": "TOPAS",
   "scopeName": "text.topas",
-  "fileTypes": ['topas'],
+  "fileTypes": ['topas','tps'],
   "patterns": [
     {
       "include": "#comment"


### PR DESCRIPTION
I use *.tps instead of *.topas file extensions so would like to add this to the automatically recognized file types